### PR TITLE
fix #11

### DIFF
--- a/simple_consumer.go
+++ b/simple_consumer.go
@@ -294,7 +294,6 @@ func (c *SimpleConsumer) Consume(offset int64, messageChan chan *FullMessage) (<
 
 	var err error
 
-	c.stop = false
 	c.offset = offset
 
 	glog.V(5).Infof("[%s][%d] offset: %d (before fetch offset)", c.topic, c.partitionID, c.offset)
@@ -332,6 +331,7 @@ func (c *SimpleConsumer) Consume(offset int64, messageChan chan *FullMessage) (<
 					c.CommitOffset()
 				case <-c.stopChanForCommit:
 					c.CommitOffset()
+					ticker.Stop()
 					return
 				}
 			}


### PR DESCRIPTION
如果refreshMeta和heartbeat同时触发了restart。第二次restart开始的时候，会调用stop()，将simple_consumer.stop置为true。而此时第一次restart启动的simple_consumer.Consume可能还没运行到c.stop=false，c.stop还会被置为false，导致simple_consumer无法停止，restart操作pending